### PR TITLE
fix(- nativeLoad): run addon not in the 'build' dir will cause NATIVE…

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function tryComplete(filename) {
 
 jsni.nativeLoad = function(filename) {
   const Module = require("module");
-  var workPath = process.cwd();
+  var workPath = require('path').dirname(process.argv[1]);
   searchPaths = [
     workPath + "/build/" + buildType,
   ]

--- a/index.js
+++ b/index.js
@@ -55,13 +55,19 @@ jsni.nativeLoad = function(filename) {
       throw err;
     }
   }
-
+  var cacheNativeModule = jsni._cache[filename_resolved];
+  if(cacheNativeModule) {
+    return cacheNativeModule;
+  }
   var native_exports = {};
+  jsni._cache[filename_resolved] = native_exports;
   nativeLoad(native_exports, filename_resolved);
   return native_exports;
 };
 
 jsni.include = '"' + __dirname + "/src/" + '"';
+
+jsni._cache = Object.create(null);
 
 global.nativeLoad = jsni.nativeLoad
 


### PR DESCRIPTION
### 1. bug fix

run addon not in the 'build' dir will cause NATIVE_MODULE_NOT_FOUND

example (**hello-world/test.js**):

```js
var jsni = require("jsni");

var addon = nativeLoad("test");

console.log(addon.hello()); // hello
```

`node test.js` is ok,
`node hello-world/test.js` will throw error: **NATIVE_MODULE_NOT_FOUND**

### 2. add native module cache