### PR TITLE
fix: fix JSNIGetPropertyNames return without handling escape.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsni",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "jsni is the interface for JavaScript and C/C++, which is vm neutral and keeps abi/api compatible. It is acronym for JavaScript Native Interface.",
   "main": "index.js",
   "scripts": {

--- a/src/jsni.cc
+++ b/src/jsni.cc
@@ -1371,5 +1371,5 @@ JSValueRef JSNIGetPropertyNames(JSNIEnv* env, JSValueRef val) {
   Local<Context> context = isolate->GetCurrentContext();
   Local<Object> object = JSNI::ToV8LocalValue(val).As<Object>();
   MaybeLocal<Array> names = object->GetPropertyNames(context);
-  return JSNI::ToJSNIValue(names.ToLocalChecked());
+  return JSNI::ToJSNIValue(scope.Escape(names.ToLocalChecked()));
 }

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -334,6 +334,7 @@ function needDumpReport() {
 function runTest(test) {
   try {
     test();
+    console.log(test.name + " passed(jsni).");
     report.pass_count += 1;
   } catch (e) {
     report.fail_count += 1;


### PR DESCRIPTION
update npm jsni version to 1.1.1.